### PR TITLE
Add param to determine if percona repo should be added

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,9 @@
 # Location where the shell script output should be logged
 # (default: '/var/log/xtrabackup.log')
 #
+# `manage_repo`
+# Parameter to determine if percona repository should be added (default: true)
+#
 #
 #
 # Examples
@@ -170,6 +173,7 @@ class xtrabackup (
   $xtrabackup_options = '',
   $innobackupx_options = '',
   $logfile = '/var/log/xtrabackup.log',
+  $manage_repo = true,
   
   
 ){

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,6 @@
 class xtrabackup::repo inherits xtrabackup {
 
-  if $xtrabackup::install_xtrabackup_bin == true {
+  if $xtrabackup::manage_repo == true {
 
     case $::operatingsystem {
       'RedHat', 'CentOS': {


### PR DESCRIPTION
If you use percona server you might already have the percona repository added by other puppet modules. If so you will get a conflict due to duplicate decleration of the percona repository resource (so  it happened for us). This can easily be fixed by avoiding the second addition of the repo by the xtrabackup module. For this it's nice to have a param to control this.